### PR TITLE
Add initial Web API skeleton

### DIFF
--- a/src/DesafioApi.sln
+++ b/src/DesafioApi.sln
@@ -1,0 +1,21 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31912.275
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DesafioApi", "DesafioApi/DesafioApi.csproj", "{3F2504E0-4F89-11D3-9A0C-0305E82C3301}"
+EndProject
+Global
+    GlobalSection(SolutionConfigurationPlatforms) = preSolution
+        Debug|Any CPU = Debug|Any CPU
+        Release|Any CPU = Release|Any CPU
+    EndGlobalSection
+    GlobalSection(ProjectConfigurationPlatforms) = postSolution
+        {3F2504E0-4F89-11D3-9A0C-0305E82C3301}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {3F2504E0-4F89-11D3-9A0C-0305E82C3301}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {3F2504E0-4F89-11D3-9A0C-0305E82C3301}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {3F2504E0-4F89-11D3-9A0C-0305E82C3301}.Release|Any CPU.Build.0 = Release|Any CPU
+    EndGlobalSection
+    GlobalSection(SolutionProperties) = preSolution
+        HideSolutionNode = FALSE
+    EndGlobalSection
+EndGlobal

--- a/src/DesafioApi/Controllers/WeatherForecastController.cs
+++ b/src/DesafioApi/Controllers/WeatherForecastController.cs
@@ -1,0 +1,33 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace DesafioApi.Controllers;
+
+[ApiController]
+[Route("[controller]")]
+public class WeatherForecastController : ControllerBase
+{
+    private static readonly string[] Summaries = new[]
+    {
+        "Freezing", "Bracing", "Chilly", "Cool", "Mild",
+        "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
+    };
+
+    private readonly ILogger<WeatherForecastController> _logger;
+
+    public WeatherForecastController(ILogger<WeatherForecastController> logger)
+    {
+        _logger = logger;
+    }
+
+    [HttpGet]
+    public IEnumerable<WeatherForecast> Get()
+    {
+        return Enumerable.Range(1, 5).Select(index => new WeatherForecast
+        {
+            Date = DateOnly.FromDateTime(DateTime.Now.AddDays(index)),
+            TemperatureC = Random.Shared.Next(-20, 55),
+            Summary = Summaries[Random.Shared.Next(Summaries.Length)]
+        })
+        .ToArray();
+    }
+}

--- a/src/DesafioApi/DesafioApi.csproj
+++ b/src/DesafioApi/DesafioApi.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+</Project>

--- a/src/DesafioApi/Program.cs
+++ b/src/DesafioApi/Program.cs
@@ -1,0 +1,23 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddControllers();
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
+
+var app = builder.Build();
+
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+app.UseAuthorization();
+
+app.MapControllers();
+
+app.Run();

--- a/src/DesafioApi/Properties/launchSettings.json
+++ b/src/DesafioApi/Properties/launchSettings.json
@@ -1,0 +1,13 @@
+{
+  "profiles": {
+    "DesafioApi": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:7071;http://localhost:5071",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/src/DesafioApi/WeatherForecast.cs
+++ b/src/DesafioApi/WeatherForecast.cs
@@ -1,0 +1,12 @@
+namespace DesafioApi;
+
+public class WeatherForecast
+{
+    public DateOnly Date { get; set; }
+
+    public int TemperatureC { get; set; }
+
+    public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
+
+    public string? Summary { get; set; }
+}

--- a/src/DesafioApi/appsettings.json
+++ b/src/DesafioApi/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}


### PR DESCRIPTION
## Summary
- manually create a .NET 6 Web API skeleton under `src/`

## Testing
- `dotnet --version` *(fails: command not found)*
- `dotnet build src/DesafioApi.sln` *(fails: command not found)*