### PR TITLE
Add Pedido and Item models with in-memory context

### DIFF
--- a/PedidoApi/Data/PedidoContext.cs
+++ b/PedidoApi/Data/PedidoContext.cs
@@ -1,0 +1,16 @@
+using Microsoft.EntityFrameworkCore;
+using PedidoApi.Models;
+
+namespace PedidoApi.Data
+{
+    public class PedidoContext : DbContext
+    {
+        public PedidoContext(DbContextOptions<PedidoContext> options)
+            : base(options)
+        {
+        }
+
+        public DbSet<Pedido> Pedidos { get; set; }
+        public DbSet<Item> Itens { get; set; }
+    }
+}

--- a/PedidoApi/Models/Item.cs
+++ b/PedidoApi/Models/Item.cs
@@ -1,0 +1,10 @@
+namespace PedidoApi.Models
+{
+    public class Item
+    {
+        public int Id { get; set; }
+        public string Descricao { get; set; } = string.Empty;
+        public decimal PrecoUnitario { get; set; }
+        public int Qtd { get; set; }
+    }
+}

--- a/PedidoApi/Models/Pedido.cs
+++ b/PedidoApi/Models/Pedido.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+
+namespace PedidoApi.Models
+{
+    public class Pedido
+    {
+        public int Id { get; set; }
+        public string Numero { get; set; } = string.Empty;
+        public ICollection<Item> Itens { get; set; } = new List<Item>();
+    }
+}

--- a/PedidoApi/PedidoApi.csproj
+++ b/PedidoApi/PedidoApi.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="7.0.0" />
+  </ItemGroup>
+</Project>

--- a/PedidoApi/Program.cs
+++ b/PedidoApi/Program.cs
@@ -1,0 +1,13 @@
+using Microsoft.EntityFrameworkCore;
+using PedidoApi.Data;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddDbContext<PedidoContext>(options =>
+    options.UseInMemoryDatabase("PedidosDb"));
+
+var app = builder.Build();
+
+app.MapGet("/", () => "Pedido API");
+
+app.Run();


### PR DESCRIPTION
## Summary
- scaffold basic .NET project `PedidoApi`
- define `Item` and `Pedido` entities
- implement `PedidoContext` using EF Core InMemory
- register the context in `Program`

## Testing
- `dotnet build PedidoApi/PedidoApi.csproj` *(fails: `dotnet` not found)*