### PR TITLE
Add Pedido controller and DTOs

### DIFF
--- a/Controllers/PedidoController.cs
+++ b/Controllers/PedidoController.cs
@@ -1,0 +1,92 @@
+using DesafioApi.Dtos;
+using DesafioApi.Models;
+using Microsoft.AspNetCore.Mvc;
+
+namespace DesafioApi.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class PedidoController : ControllerBase
+    {
+        private readonly PedidoContext _context;
+
+        public PedidoController(PedidoContext context)
+        {
+            _context = context;
+        }
+
+        [HttpGet("{numero}")]
+        public ActionResult<PedidoDto> Get(string numero)
+        {
+            var pedido = _context.Get(numero);
+            if (pedido == null)
+                return NotFound();
+
+            return Ok(ToDto(pedido));
+        }
+
+        [HttpPost]
+        public ActionResult<PedidoDto> Post([FromBody] PedidoDto dto)
+        {
+            if (!ModelState.IsValid)
+                return ValidationProblem(ModelState);
+
+            var pedido = FromDto(dto);
+            _context.Add(pedido);
+            return CreatedAtAction(nameof(Get), new { numero = pedido.Numero }, dto);
+        }
+
+        [HttpPut("{numero}")]
+        public IActionResult Put(string numero, [FromBody] PedidoDto dto)
+        {
+            if (!ModelState.IsValid)
+                return ValidationProblem(ModelState);
+
+            var pedido = _context.Get(numero);
+            if (pedido == null)
+                return NotFound();
+
+            pedido.Itens = dto.Itens.Select(i => new PedidoItem
+            {
+                Descricao = i.Descricao,
+                PrecoUnitario = i.PrecoUnitario,
+                Qtd = i.Qtd
+            }).ToList();
+            _context.Update(pedido);
+            return NoContent();
+        }
+
+        [HttpDelete("{numero}")]
+        public IActionResult Delete(string numero)
+        {
+            var pedido = _context.Get(numero);
+            if (pedido == null)
+                return NotFound();
+
+            _context.Delete(numero);
+            return NoContent();
+        }
+
+        private static PedidoDto ToDto(Pedido pedido) => new PedidoDto
+        {
+            Pedido = pedido.Numero,
+            Itens = pedido.Itens.Select(i => new PedidoItemDto
+            {
+                Descricao = i.Descricao,
+                PrecoUnitario = i.PrecoUnitario,
+                Qtd = i.Qtd
+            }).ToList()
+        };
+
+        private static Pedido FromDto(PedidoDto dto) => new Pedido
+        {
+            Numero = dto.Pedido,
+            Itens = dto.Itens.Select(i => new PedidoItem
+            {
+                Descricao = i.Descricao,
+                PrecoUnitario = i.PrecoUnitario,
+                Qtd = i.Qtd
+            }).ToList()
+        };
+    }
+}

--- a/DesafioApi.csproj
+++ b/DesafioApi.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+</Project>

--- a/Dtos/PedidoDto.cs
+++ b/Dtos/PedidoDto.cs
@@ -1,0 +1,14 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace DesafioApi.Dtos
+{
+    public class PedidoDto
+    {
+        [Required]
+        public string Pedido { get; set; } = string.Empty;
+
+        [Required]
+        [MinLength(1)]
+        public List<PedidoItemDto> Itens { get; set; } = new();
+    }
+}

--- a/Dtos/PedidoItemDto.cs
+++ b/Dtos/PedidoItemDto.cs
@@ -1,0 +1,16 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace DesafioApi.Dtos
+{
+    public class PedidoItemDto
+    {
+        [Required]
+        public string Descricao { get; set; } = string.Empty;
+
+        [Range(0.01, double.MaxValue)]
+        public decimal PrecoUnitario { get; set; }
+
+        [Range(1, int.MaxValue)]
+        public int Qtd { get; set; }
+    }
+}

--- a/Models/Pedido.cs
+++ b/Models/Pedido.cs
@@ -1,0 +1,8 @@
+namespace DesafioApi.Models
+{
+    public class Pedido
+    {
+        public string Numero { get; set; } = string.Empty;
+        public List<PedidoItem> Itens { get; set; } = new();
+    }
+}

--- a/Models/PedidoItem.cs
+++ b/Models/PedidoItem.cs
@@ -1,0 +1,9 @@
+namespace DesafioApi.Models
+{
+    public class PedidoItem
+    {
+        public string Descricao { get; set; } = string.Empty;
+        public decimal PrecoUnitario { get; set; }
+        public int Qtd { get; set; }
+    }
+}

--- a/PedidoContext.cs
+++ b/PedidoContext.cs
@@ -1,0 +1,22 @@
+using DesafioApi.Models;
+
+namespace DesafioApi;
+
+public class PedidoContext
+{
+    private readonly Dictionary<string, Pedido> _pedidos = new();
+
+    public IEnumerable<Pedido> List() => _pedidos.Values;
+
+    public Pedido? Get(string numero)
+    {
+        _pedidos.TryGetValue(numero, out var pedido);
+        return pedido;
+    }
+
+    public void Add(Pedido pedido) => _pedidos[pedido.Numero] = pedido;
+
+    public void Update(Pedido pedido) => _pedidos[pedido.Numero] = pedido;
+
+    public void Delete(string numero) => _pedidos.Remove(numero);
+}

--- a/Program.cs
+++ b/Program.cs
@@ -1,0 +1,9 @@
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddSingleton<PedidoContext>();
+builder.Services.AddControllers();
+
+var app = builder.Build();
+app.MapControllers();
+
+app.Run();


### PR DESCRIPTION
## Summary
- add basic Web API project setup
- implement `PedidoController` with CRUD operations
- create DTOs for validating requests
- stub in-memory `PedidoContext`

## Testing
- `dotnet build` *(fails: `dotnet` not found)*