### PR TITLE
Add status service and controller

### DIFF
--- a/instructions.md
+++ b/instructions.md
@@ -1,0 +1,12 @@
+# How to Run
+
+This project uses Node.js without external dependencies.
+
+1. Ensure Node.js is installed.
+2. From the repository root run:
+   ```bash
+   node src/server.js
+   ```
+3. The server will listen on port 3000 by default.
+
+Use `POST /api/status` with JSON payload to test the service.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "desafio-back-end",
+  "version": "1.0.0",
+  "description": "<img src=\"transferir.png\" width=\"200\" alt=\"Parfois\"> # Back-end Challenge",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/src/controllers/statusController.js
+++ b/src/controllers/statusController.js
@@ -1,0 +1,22 @@
+const StatusRequest = require('../dtos/statusRequest');
+const statusService = require('../services/statusService');
+
+function handleStatus(req, res) {
+  let body = '';
+  req.on('data', chunk => body += chunk);
+  req.on('end', () => {
+    try {
+      const data = JSON.parse(body);
+      const request = new StatusRequest(data);
+      const result = statusService.process(request);
+      res.statusCode = 200;
+      res.setHeader('Content-Type', 'application/json');
+      res.end(JSON.stringify(result));
+    } catch (err) {
+      res.statusCode = 400;
+      res.end(JSON.stringify({ error: 'Invalid request' }));
+    }
+  });
+}
+
+module.exports = { handleStatus };

--- a/src/dtos/statusRequest.js
+++ b/src/dtos/statusRequest.js
@@ -1,0 +1,10 @@
+class StatusRequest {
+  constructor({ status, itensAprovados, valorAprovado, pedido }) {
+    this.status = status;
+    this.itensAprovados = Number(itensAprovados);
+    this.valorAprovado = Number(valorAprovado);
+    this.pedido = pedido;
+  }
+}
+
+module.exports = StatusRequest;

--- a/src/orders.js
+++ b/src/orders.js
@@ -1,0 +1,15 @@
+const orders = [
+  {
+    pedido: '123456',
+    itens: [
+      { descricao: 'Item A', precoUnitario: 10, qtd: 1 },
+      { descricao: 'Item B', precoUnitario: 5, qtd: 2 }
+    ]
+  }
+];
+
+function getOrderById(id) {
+  return orders.find(o => o.pedido === id);
+}
+
+module.exports = { orders, getOrderById };

--- a/src/server.js
+++ b/src/server.js
@@ -1,0 +1,13 @@
+const http = require('http');
+const { handleStatus } = require('./controllers/statusController');
+
+const server = http.createServer((req, res) => {
+  if (req.method === 'POST' && req.url === '/api/status') {
+    return handleStatus(req, res);
+  }
+  res.statusCode = 404;
+  res.end();
+});
+
+const PORT = process.env.PORT || 3000;
+server.listen(PORT, () => console.log(`Server running on port ${PORT}`));

--- a/src/services/statusService.js
+++ b/src/services/statusService.js
@@ -1,0 +1,35 @@
+const { getOrderById } = require('../orders');
+
+function computeTotals(order) {
+  const totalItems = order.itens.reduce((sum, i) => sum + i.qtd, 0);
+  const totalValue = order.itens.reduce((sum, i) => sum + i.precoUnitario * i.qtd, 0);
+  return { totalItems, totalValue };
+}
+
+function process(request) {
+  const order = getOrderById(request.pedido);
+  if (!order) {
+    return { pedido: request.pedido, status: ['CODIGO_PEDIDO_INVALIDO'] };
+  }
+  const { totalItems, totalValue } = computeTotals(order);
+  const statuses = [];
+
+  if (request.status === 'REPROVADO') {
+    statuses.push('REPROVADO');
+  }
+
+  if (request.status === 'APROVADO') {
+    if (request.itensAprovados === totalItems && request.valorAprovado === totalValue) {
+      statuses.push('APROVADO');
+    } else {
+      if (request.valorAprovado < totalValue) statuses.push('APROVADO_VALOR_A_MENOR');
+      if (request.valorAprovado > totalValue) statuses.push('APROVADO_VALOR_A_MAIOR');
+      if (request.itensAprovados < totalItems) statuses.push('APROVADO_QTD_A_MENOR');
+      if (request.itensAprovados > totalItems) statuses.push('APROVADO_QTD_A_MAIOR');
+    }
+  }
+
+  return { pedido: request.pedido, status: statuses };
+}
+
+module.exports = { process };


### PR DESCRIPTION
## Summary
- add instructions on how to run
- setup package.json
- add request DTO for status change
- implement status service with business rules
- expose POST /api/status via controller
- create simple HTTP server for the endpoint

## Testing
- `npm test` *(fails: Error: no test specified)*