### PR TITLE
Add xUnit test suite for Pedido and status rules

### DIFF
--- a/src/DesafioBackend/DesafioBackend.csproj
+++ b/src/DesafioBackend/DesafioBackend.csproj
@@ -1,0 +1,6 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+</Project>

--- a/src/DesafioBackend/Item.cs
+++ b/src/DesafioBackend/Item.cs
@@ -1,0 +1,8 @@
+namespace DesafioBackend;
+
+public class Item
+{
+    public string Descricao { get; set; } = string.Empty;
+    public decimal PrecoUnitario { get; set; }
+    public int Qtd { get; set; }
+}

--- a/src/DesafioBackend/Pedido.cs
+++ b/src/DesafioBackend/Pedido.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using System.Linq;
+namespace DesafioBackend;
+
+public class Pedido
+{
+    public string Numero { get; set; } = string.Empty;
+    public List<Item> Itens { get; set; } = new List<Item>();
+
+    public decimal ValorTotal => Itens.Sum(i => i.PrecoUnitario * i.Qtd);
+    public int QuantidadeTotal => Itens.Sum(i => i.Qtd);
+}

--- a/src/DesafioBackend/PedidoRepository.cs
+++ b/src/DesafioBackend/PedidoRepository.cs
@@ -1,0 +1,16 @@
+using System.Collections.Concurrent;
+
+namespace DesafioBackend;
+
+public class PedidoRepository
+{
+    private readonly ConcurrentDictionary<string, Pedido> _data = new();
+
+    public void Add(Pedido pedido) => _data[pedido.Numero] = pedido;
+
+    public Pedido? Get(string numero) => _data.TryGetValue(numero, out var p) ? p : null;
+
+    public void Update(Pedido pedido) => _data[pedido.Numero] = pedido;
+
+    public void Delete(string numero) => _data.TryRemove(numero, out _);
+}

--- a/src/DesafioBackend/PedidoService.cs
+++ b/src/DesafioBackend/PedidoService.cs
@@ -1,0 +1,19 @@
+namespace DesafioBackend;
+
+public class PedidoService
+{
+    private readonly PedidoRepository _repo;
+
+    public PedidoService(PedidoRepository repo)
+    {
+        _repo = repo;
+    }
+
+    public void Criar(Pedido pedido) => _repo.Add(pedido);
+
+    public Pedido? Obter(string numero) => _repo.Get(numero);
+
+    public void Atualizar(Pedido pedido) => _repo.Update(pedido);
+
+    public void Remover(string numero) => _repo.Delete(numero);
+}

--- a/src/DesafioBackend/StatusRequest.cs
+++ b/src/DesafioBackend/StatusRequest.cs
@@ -1,0 +1,9 @@
+namespace DesafioBackend;
+
+public class StatusRequest
+{
+    public string Status { get; set; } = string.Empty;
+    public int ItensAprovados { get; set; }
+    public decimal ValorAprovado { get; set; }
+    public string Pedido { get; set; } = string.Empty;
+}

--- a/src/DesafioBackend/StatusService.cs
+++ b/src/DesafioBackend/StatusService.cs
@@ -1,0 +1,40 @@
+namespace DesafioBackend;
+
+public class StatusService
+{
+    public List<string> Avaliar(Pedido pedido, StatusRequest request)
+    {
+        var result = new List<string>();
+        if (request.Status == "REPROVADO")
+        {
+            result.Add("REPROVADO");
+            return result;
+        }
+
+        if (request.Status == "APROVADO")
+        {
+            if (request.ValorAprovado == pedido.ValorTotal && request.ItensAprovados == pedido.QuantidadeTotal)
+            {
+                result.Add("APROVADO");
+                return result;
+            }
+            if (request.ValorAprovado < pedido.ValorTotal)
+            {
+                result.Add("APROVADO_VALOR_A_MENOR");
+            }
+            else if (request.ValorAprovado > pedido.ValorTotal)
+            {
+                result.Add("APROVADO_VALOR_A_MAIOR");
+            }
+            if (request.ItensAprovados < pedido.QuantidadeTotal)
+            {
+                result.Add("APROVADO_QTD_A_MENOR");
+            }
+            else if (request.ItensAprovados > pedido.QuantidadeTotal)
+            {
+                result.Add("APROVADO_QTD_A_MAIOR");
+            }
+        }
+        return result;
+    }
+}

--- a/tests/DesafioBackend.Tests/DesafioBackend.Tests.csproj
+++ b/tests/DesafioBackend.Tests/DesafioBackend.Tests.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="xunit" Version="2.5.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\DesafioBackend\DesafioBackend.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/DesafioBackend.Tests/PedidoServiceTests.cs
+++ b/tests/DesafioBackend.Tests/PedidoServiceTests.cs
@@ -1,0 +1,42 @@
+using Xunit;
+using DesafioBackend;
+
+public class PedidoServiceTests
+{
+    [Fact]
+    public void Criar_E_Pegar_Pedido()
+    {
+        var repo = new PedidoRepository();
+        var service = new PedidoService(repo);
+        var pedido = new Pedido { Numero = "1" };
+        service.Criar(pedido);
+        var result = service.Obter("1");
+        Assert.NotNull(result);
+        Assert.Equal("1", result?.Numero);
+    }
+
+    [Fact]
+    public void Atualizar_Pedido()
+    {
+        var repo = new PedidoRepository();
+        var service = new PedidoService(repo);
+        var pedido = new Pedido { Numero = "1" };
+        service.Criar(pedido);
+        pedido.Itens.Add(new Item { Descricao = "A", PrecoUnitario = 1, Qtd = 1 });
+        service.Atualizar(pedido);
+        var result = service.Obter("1");
+        Assert.Single(result!.Itens);
+    }
+
+    [Fact]
+    public void Remover_Pedido()
+    {
+        var repo = new PedidoRepository();
+        var service = new PedidoService(repo);
+        var pedido = new Pedido { Numero = "1" };
+        service.Criar(pedido);
+        service.Remover("1");
+        var result = service.Obter("1");
+        Assert.Null(result);
+    }
+}

--- a/tests/DesafioBackend.Tests/StatusServiceTests.cs
+++ b/tests/DesafioBackend.Tests/StatusServiceTests.cs
@@ -1,0 +1,81 @@
+using System.Collections.Generic;
+using Xunit;
+using DesafioBackend;
+
+public class StatusServiceTests
+{
+    private Pedido CriarPedidoPadrao()
+    {
+        return new Pedido
+        {
+            Numero = "1",
+            Itens = new List<Item>
+            {
+                new Item { Descricao = "A", PrecoUnitario = 10, Qtd = 1 },
+                new Item { Descricao = "B", PrecoUnitario = 5, Qtd = 2 }
+            }
+        };
+    }
+
+    [Fact]
+    public void Status_Aprovado_Total()
+    {
+        var pedido = CriarPedidoPadrao();
+        var service = new StatusService();
+        var req = new StatusRequest
+        {
+            Status = "APROVADO",
+            ValorAprovado = pedido.ValorTotal,
+            ItensAprovados = pedido.QuantidadeTotal
+        };
+        var result = service.Avaliar(pedido, req);
+        Assert.Equal(new[]{"APROVADO"}, result);
+    }
+
+    [Fact]
+    public void Status_Valor_Menor_Qtd_Menor()
+    {
+        var pedido = CriarPedidoPadrao();
+        var service = new StatusService();
+        var req = new StatusRequest
+        {
+            Status = "APROVADO",
+            ValorAprovado = pedido.ValorTotal - 1,
+            ItensAprovados = pedido.QuantidadeTotal - 1
+        };
+        var result = service.Avaliar(pedido, req);
+        Assert.Contains("APROVADO_VALOR_A_MENOR", result);
+        Assert.Contains("APROVADO_QTD_A_MENOR", result);
+    }
+
+    [Fact]
+    public void Status_Valor_Maior_Qtd_Maior()
+    {
+        var pedido = CriarPedidoPadrao();
+        var service = new StatusService();
+        var req = new StatusRequest
+        {
+            Status = "APROVADO",
+            ValorAprovado = pedido.ValorTotal + 1,
+            ItensAprovados = pedido.QuantidadeTotal + 1
+        };
+        var result = service.Avaliar(pedido, req);
+        Assert.Contains("APROVADO_VALOR_A_MAIOR", result);
+        Assert.Contains("APROVADO_QTD_A_MAIOR", result);
+    }
+
+    [Fact]
+    public void Status_Reprovado()
+    {
+        var pedido = CriarPedidoPadrao();
+        var service = new StatusService();
+        var req = new StatusRequest
+        {
+            Status = "REPROVADO",
+            ValorAprovado = 0,
+            ItensAprovados = 0
+        };
+        var result = service.Avaliar(pedido, req);
+        Assert.Equal(new[]{"REPROVADO"}, result);
+    }
+}


### PR DESCRIPTION
## Summary
- add DesafioBackend library with Pedido domain logic
- add xUnit test project covering CRUD and status rule scenarios

## Testing
- `dotnet test tests/DesafioBackend.Tests/DesafioBackend.Tests.csproj` *(fails: dotnet not found)*